### PR TITLE
Dev maria

### DIFF
--- a/.github/ISSUE_TEMPLATE/technical debt.md
+++ b/.github/ISSUE_TEMPLATE/technical debt.md
@@ -1,1 +1,38 @@
+---
+name: Technical Debt report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
 
+---
+
+**Describe the technical debt**
+A clear and concise description of what the technical debt is.
+
+**To Reproduce // if applicable**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of the proposed solution. Best is to show original technical debt and the resolution.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information): // if needed**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/jme3-android/src/main/java/com/jme3/asset/plugins/AndroidLocator.java
+++ b/jme3-android/src/main/java/com/jme3/asset/plugins/AndroidLocator.java
@@ -91,7 +91,7 @@ public class AndroidLocator implements AssetLocator {
         private InputStream in;
         private final String assetPath;
         private int resourceId;
-
+        private static final String AssetOpenError="Failed to open asset";
         AndroidAssetInfo(AssetManager assetManager, AssetKey<?> key, String assetPath, InputStream in, int resourceId) {
             super(assetManager, key);
             this.assetPath = assetPath;
@@ -113,13 +113,13 @@ public class AndroidLocator implements AssetLocator {
                     try {
                         return androidResources.getAssets().open(assetPath);
                     } catch (IOException ex) {
-                        throw new AssetLoadException("Failed to open asset " + assetPath, ex);
+                        throw new AssetLoadException(AssetOpenError + assetPath, ex);
                     }
                 } else {
                     try {
                         return androidResources.openRawResource(resourceId);
                     } catch (Resources.NotFoundException ex) {
-                        throw new AssetLoadException("Failed to open asset " + assetPath, ex);
+                        throw new AssetLoadException(AssetOpenError + assetPath, ex);
                     }
                 }
             }
@@ -131,13 +131,13 @@ public class AndroidLocator implements AssetLocator {
                 try {
                     return androidResources.getAssets().openFd(assetPath);
                 } catch (IOException ex) {
-                    throw new AssetLoadException("Failed to open asset " + assetPath, ex);
+                    throw new AssetLoadException(AssetOpenError + assetPath, ex);
                 }
             } else {
                 try {
                     return androidResources.openRawResourceFd(resourceId);
                 } catch (Resources.NotFoundException ex) {
-                    throw new AssetLoadException("Failed to open asset " + assetPath, ex);
+                    throw new AssetLoadException(AssetOpenError + assetPath, ex);
                 }
             }
         }


### PR DESCRIPTION
Defined a constant instead of duplicating this literal “Failed to asset” 4 times. Constants can be referenced from many places, but only need to be updated in a single place.
Reason:Duplicated string literals make the refactoring process complex and error-prone, as any change would need to be propagated on all occurrences.