### PR TITLE
Removed this use of "TYPE_ORIENTATION"; since it is deprecated.

### DIFF
--- a/jme3-android/src/main/java/com/jme3/input/android/AndroidSensorJoyInput.java
+++ b/jme3-android/src/main/java/com/jme3/input/android/AndroidSensorJoyInput.java
@@ -212,7 +212,7 @@ public class AndroidSensorJoyInput implements SensorEventListener {
      */
     public void resumeSensors() {
         for (Entry entry: sensors) {
-            if (entry.getKey() != Sensor.TYPE_ORIENTATION) {
+            if (entry.getKey() != Sensor.TYPE_ROTATION_VECTOR) {
                 registerListener(entry.getKey());
             }
         }


### PR DESCRIPTION
Issue found:
---
Remove this use of "TYPE_ORIENTATION"; it is deprecated.

Fix:
---
if (entry.getKey() != Sensor.TYPE_ROTATION_VECTOR)

Sonar scan passed.
---