### PR TITLE
The block of commented-out lines of code is removed to reduce technical debt

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,10 @@ buildscript {
     }
 }
 
+plugins {
+  id "org.sonarqube" version "5.1.0.4882"
+}
+
 allprojects {
     repositories {
         mavenCentral()

--- a/jme3-android/src/main/java/com/jme3/app/DefaultAndroidProfiler.java
+++ b/jme3-android/src/main/java/com/jme3/app/DefaultAndroidProfiler.java
@@ -35,7 +35,7 @@ package com.jme3.app;
 import android.os.Build;
 import com.jme3.profile.*;
 
-import static com.jme3.profile.AppStep.BeginFrame;
+
 import static com.jme3.profile.AppStep.EndFrame;
 import static com.jme3.profile.AppStep.ProcessAudio;
 import static com.jme3.profile.AppStep.ProcessInput;

--- a/jme3-android/src/main/java/com/jme3/app/DefaultAndroidProfiler.java
+++ b/jme3-android/src/main/java/com/jme3/app/DefaultAndroidProfiler.java
@@ -36,7 +36,7 @@ import android.os.Build;
 import com.jme3.profile.*;
 
 
-import static com.jme3.profile.AppStep.EndFrame;
+
 import static com.jme3.profile.AppStep.ProcessAudio;
 import static com.jme3.profile.AppStep.ProcessInput;
 import static com.jme3.profile.AppStep.QueuedTasks;

--- a/jme3-android/src/main/java/com/jme3/app/state/MjpegFileWriter.java
+++ b/jme3-android/src/main/java/com/jme3/app/state/MjpegFileWriter.java
@@ -216,14 +216,7 @@ public class MjpegFileWriter {
     }
 
     private class AVIMainHeader {
-        /*
-         *
-         * FOURCC fcc; DWORD cb; DWORD dwMicroSecPerFrame; DWORD
-         * dwMaxBytesPerSec; DWORD dwPaddingGranularity; DWORD dwFlags; DWORD
-         * dwTotalFrames; DWORD dwInitialFrames; DWORD dwStreams; DWORD
-         * dwSuggestedBufferSize; DWORD dwWidth; DWORD dwHeight; DWORD
-         * dwReserved[4];
-         */
+
 
         public byte[] fcc = new byte[]{'a', 'v', 'i', 'h'};
         public int cb = 56;

--- a/jme3-android/src/main/java/com/jme3/app/state/MjpegFileWriter.java
+++ b/jme3-android/src/main/java/com/jme3/app/state/MjpegFileWriter.java
@@ -369,13 +369,6 @@ public class MjpegFileWriter {
     }
 
     private class AVIStreamFormat {
-        /*
-         * FOURCC fcc; DWORD cb; DWORD biSize; LONG biWidth; LONG biHeight; WORD
-         * biPlanes; WORD biBitCount; DWORD biCompression; DWORD biSizeImage;
-         * LONG biXPelsPerMeter; LONG biYPelsPerMeter; DWORD biClrUsed; DWORD
-         * biClrImportant;
-         */
-
         public byte[] fcc = new byte[]{'s', 't', 'r', 'f'};
         public int cb = 40;
         public int biSize = 40;                               // same

--- a/jme3-android/src/main/java/com/jme3/app/state/MjpegFileWriter.java
+++ b/jme3-android/src/main/java/com/jme3/app/state/MjpegFileWriter.java
@@ -113,7 +113,7 @@ public class MjpegFileWriter {
                 aviOutput.write(0);
             }
         }
-        imagedata = null;
+
 
         numFrames++; //add a frame
     }

--- a/jme3-desktop/src/main/java/com/jme3/app/state/AWTComponentAppState.java
+++ b/jme3-desktop/src/main/java/com/jme3/app/state/AWTComponentAppState.java
@@ -34,8 +34,6 @@ package com.jme3.app.state;
 import java.awt.Component;
 
 import com.jme3.app.Application;
-import com.jme3.app.state.AbstractAppState;
-import com.jme3.app.state.AppStateManager;
 import com.jme3.system.AWTFrameProcessor;
 import com.jme3.system.AWTTaskExecutor;
 

--- a/jme3-desktop/src/main/java/com/jme3/app/state/MjpegFileWriter.java
+++ b/jme3-desktop/src/main/java/com/jme3/app/state/MjpegFileWriter.java
@@ -98,7 +98,7 @@ public class MjpegFileWriter implements AutoCloseable {
         aviOutput.write(listBytes);
         indexlist = new AVIIndexList();
 
-        position = headerBytes.length + listBytes.length;
+        position = (long) headerBytes.length + listBytes.length;
     }
 
     public void addImage(Image image) throws Exception {
@@ -130,7 +130,6 @@ public class MjpegFileWriter implements AutoCloseable {
         }
         byte[] data = baos.toByteArray();
         aviOutput.write(data);
-        imageData = null;
 
         numFrames++; //add a frame
         position += data.length;

--- a/jme3-desktop/src/main/java/com/jme3/app/state/MjpegFileWriter.java
+++ b/jme3-desktop/src/main/java/com/jme3/app/state/MjpegFileWriter.java
@@ -158,17 +158,6 @@ public class MjpegFileWriter implements AutoCloseable {
         }
     }
 
-    // public void writeAVI(File file) throws Exception
-    // {
-    // OutputStream os = new FileOutputStream(file);
-    //
-    // // RIFFHeader
-    // // AVIMainHeader
-    // // AVIStreamList
-    // // AVIStreamHeader
-    // // AVIStreamFormat
-    // // write 00db and image bytes...
-    // }
     public static int swapInt(int v) {
         return (v >>> 24) | (v << 24) | ((v << 8) & 0x00FF0000) | ((v >> 8) & 0x0000FF00);
     }

--- a/jme3-desktop/src/main/java/com/jme3/cursors/plugins/CursorLoader.java
+++ b/jme3-desktop/src/main/java/com/jme3/cursors/plugins/CursorLoader.java
@@ -667,7 +667,7 @@ public class CursorLoader implements AssetLoader {
                 hotspotx = 0;
                 hotspoty = height - 1;
             }
-//            System.out.println("Image type = " + (type == 1 ? "CUR" : "ICO"));
+
             if (rate == 0) {
                 rate = jiffy;
             }

--- a/jme3-desktop/src/main/java/com/jme3/cursors/plugins/CursorLoader.java
+++ b/jme3-desktop/src/main/java/com/jme3/cursors/plugins/CursorLoader.java
@@ -370,7 +370,7 @@ public class CursorLoader implements AssetLoader {
                             colorCount[i] = (int) Math.pow(2, bitCount);
                         }
                     } else {
-                        colorCount[i] = (int) Math.pow(2, bitCount * planes);
+                        colorCount[i] = (int) Math.pow(2, (double) bitCount * planes);
                     }
                 }
 

--- a/jme3-desktop/src/main/java/com/jme3/cursors/plugins/CursorLoader.java
+++ b/jme3-desktop/src/main/java/com/jme3/cursors/plugins/CursorLoader.java
@@ -274,8 +274,8 @@ public class CursorLoader implements AssetLoader {
 
         BufferedImage[] bi;
         // Check resource type field.
-        int DE_LENGTH = 16; // directory entry length
-        int BMIH_LENGTH = 40; // BITMAPINFOHEADER length
+        int deLength = 16; // directory entry length
+        int bmihLength = 40; // BITMAPINFOHEADER length
 
         if (icoImage[2] != 1 && icoImage[2] != 2 || icoImage[3] != 0) {
             throw new IllegalArgumentException("Bad data in ICO/CUR file. ImageType has to be either 1 or 2.");
@@ -288,27 +288,27 @@ public class CursorLoader implements AssetLoader {
         int[] colorCount = new int[numImages];
 
         for (int i = 0; i < numImages; i++) {
-            int width = ubyte(icoImage[FDE_OFFSET + i * DE_LENGTH]);
+            int width = ubyte(icoImage[FDE_OFFSET + i * deLength]);
 
-            int height = ubyte(icoImage[FDE_OFFSET + i * DE_LENGTH + 1]);
+            int height = ubyte(icoImage[FDE_OFFSET + i * deLength + 1]);
 
-            colorCount[i] = ubyte(icoImage[FDE_OFFSET + i * DE_LENGTH + 2]);
+            colorCount[i] = ubyte(icoImage[FDE_OFFSET + i * deLength + 2]);
 
-            int bytesInRes = ubyte(icoImage[FDE_OFFSET + i * DE_LENGTH + 11]);
+            int bytesInRes = ubyte(icoImage[FDE_OFFSET + i * deLength + 11]);
             bytesInRes <<= 8;
-            bytesInRes |= ubyte(icoImage[FDE_OFFSET + i * DE_LENGTH + 10]);
+            bytesInRes |= ubyte(icoImage[FDE_OFFSET + i * deLength + 10]);
             bytesInRes <<= 8;
-            bytesInRes |= ubyte(icoImage[FDE_OFFSET + i * DE_LENGTH + 9]);
+            bytesInRes |= ubyte(icoImage[FDE_OFFSET + i * deLength + 9]);
             bytesInRes <<= 8;
-            bytesInRes |= ubyte(icoImage[FDE_OFFSET + i * DE_LENGTH + 8]);
+            bytesInRes |= ubyte(icoImage[FDE_OFFSET + i * deLength + 8]);
 
-            int imageOffset = ubyte(icoImage[FDE_OFFSET + i * DE_LENGTH + 15]);
+            int imageOffset = ubyte(icoImage[FDE_OFFSET + i * deLength + 15]);
             imageOffset <<= 8;
-            imageOffset |= ubyte(icoImage[FDE_OFFSET + i * DE_LENGTH + 14]);
+            imageOffset |= ubyte(icoImage[FDE_OFFSET + i * deLength + 14]);
             imageOffset <<= 8;
-            imageOffset |= ubyte(icoImage[FDE_OFFSET + i * DE_LENGTH + 13]);
+            imageOffset |= ubyte(icoImage[FDE_OFFSET + i * deLength + 13]);
             imageOffset <<= 8;
-            imageOffset |= ubyte(icoImage[FDE_OFFSET + i * DE_LENGTH + 12]);
+            imageOffset |= ubyte(icoImage[FDE_OFFSET + i * deLength + 12]);
 
             if (icoImage[imageOffset] == 40
                     && icoImage[imageOffset + 1] == 0
@@ -378,7 +378,7 @@ public class CursorLoader implements AssetLoader {
 
                 // Parse image to image buffer.
 
-                int colorTableOffset = imageOffset + BMIH_LENGTH;
+                int colorTableOffset = imageOffset + bmihLength;
 
                 if (colorCount[i] == 2) {
                     int xorImageOffset = colorTableOffset + 2 * 4;

--- a/jme3-desktop/src/main/java/jme3tools/converters/ImageToAwt.java
+++ b/jme3-desktop/src/main/java/jme3tools/converters/ImageToAwt.java
@@ -49,7 +49,17 @@ public class ImageToAwt {
 
     private static class DecodeParams {
 
-        final int bpp, am, rm, gm, bm, as, rs, gs, bs, im, is;
+        final int bpp;
+        final int am;
+        final int rm;
+        final int gm;
+        final int bm;
+        final int as;
+        final int rs;
+        final int gs;
+        final int bs;
+        final int im;
+        final int is;
 
         public DecodeParams(int bpp, int am, int rm, int gm, int bm, int as, int rs, int gs, int bs, int im, int is) {
             this.bpp = bpp;


### PR DESCRIPTION
In the file MjpegFileWriter.java, there is a commented-out code. Commented-out code distracts the focus from the actual executed code. It creates a noise that increases maintenance code. And because it is never executed, it quickly becomes out of date and invalid. Which is a technical debt. Commented-out code should be deleted and removed.